### PR TITLE
fix issues with uncompile dependencies

### DIFF
--- a/lib/mix/tasks/deps.changelog.ex
+++ b/lib/mix/tasks/deps.changelog.ex
@@ -44,6 +44,8 @@ defmodule Mix.Tasks.Deps.Changelog do
 
   def run(["--before"]) do
     try do
+      # Compile dependencies to ensure status information is available
+      Mix.Task.run("deps.compile")
       original_deps_info = Mix.Dep.load_and_cache()
       changelogs_before = before_update(original_deps_info)
       record = {original_deps_info, changelogs_before}
@@ -112,6 +114,9 @@ defmodule Mix.Tasks.Deps.Changelog do
     # (UndefinedFunctionError) function Hex.Mix.overridden_deps/1 is undefined (module Hex.Mix is not available)
     Mix.ensure_application!(:hex)
     Mix.Task.run(embedded_task, task_args)
+
+    # Compile dependencies after update to ensure proper status information
+    Mix.Task.run("deps.compile")
 
     Mix.Task.reenable("deps.changelog")
     Mix.Task.run("deps.changelog", ["--after"])
@@ -274,20 +279,44 @@ defmodule Mix.Tasks.Deps.Changelog do
     |> elem(1)
   end
 
+  # Helper function to extract version from dependency, trying multiple sources
+  defp get_dep_version(dep) do
+    case dep.status do
+      {_status, version} when is_binary(version) -> 
+        version
+      _ ->
+        # Try to get version from lock info in opts
+        case Keyword.get(dep.opts, :lock) do
+          {_scm, _name, version, _hash, _build_tools, _deps, _repo, _checksum} when is_binary(version) ->
+            version
+          {_scm, _name, version, _hash} when is_binary(version) ->
+            version
+          _ -> nil
+        end
+    end
+  end
+
   # from Igniter
   defp dep_changes_in_order(old_deps_info, new_deps_info) do
     new_deps_info
     |> sort_deps()
     |> Enum.flat_map(fn dep ->
-      case Enum.find(old_deps_info, &(&1.app == dep.app)) do
+      case get_dep_version(dep) do
         nil ->
-          [{dep.app, nil, Version.parse!(elem(dep.status, 1))}]
-
-        %{status: {:ok, old_version}} ->
-          [{dep.app, Version.parse!(old_version), Version.parse!(elem(dep.status, 1))}]
-
-        _other ->
+          # Skip dependencies without any version information
           []
+
+        new_version ->
+          case Enum.find(old_deps_info, &(&1.app == dep.app)) do
+            nil ->
+              [{dep.app, nil, Version.parse!(new_version)}]
+
+            old_dep ->
+              case get_dep_version(old_dep) do
+                nil -> []
+                old_version -> [{dep.app, Version.parse!(old_version), Version.parse!(new_version)}]
+              end
+          end
       end
     end)
     |> Enum.reject(fn {_app, old, new} ->

--- a/lib/mix/tasks/deps.changelog.ex
+++ b/lib/mix/tasks/deps.changelog.ex
@@ -282,16 +282,21 @@ defmodule Mix.Tasks.Deps.Changelog do
   # Helper function to extract version from dependency, trying multiple sources
   defp get_dep_version(dep) do
     case dep.status do
-      {_status, version} when is_binary(version) -> 
+      {_status, version} when is_binary(version) ->
         version
+
       _ ->
         # Try to get version from lock info in opts
         case Keyword.get(dep.opts, :lock) do
-          {_scm, _name, version, _hash, _build_tools, _deps, _repo, _checksum} when is_binary(version) ->
+          {_scm, _name, version, _hash, _build_tools, _deps, _repo, _checksum}
+          when is_binary(version) ->
             version
+
           {_scm, _name, version, _hash} when is_binary(version) ->
             version
-          _ -> nil
+
+          _ ->
+            nil
         end
     end
   end
@@ -314,8 +319,11 @@ defmodule Mix.Tasks.Deps.Changelog do
 
             old_dep ->
               case get_dep_version(old_dep) do
-                nil -> []
-                old_version -> [{dep.app, Version.parse!(old_version), Version.parse!(new_version)}]
+                nil ->
+                  []
+
+                old_version ->
+                  [{dep.app, Version.parse!(old_version), Version.parse!(new_version)}]
               end
           end
       end

--- a/lib/mix/tasks/deps.changelog.ex
+++ b/lib/mix/tasks/deps.changelog.ex
@@ -297,7 +297,8 @@ defmodule Mix.Tasks.Deps.Changelog do
   end
 
   # from Igniter
-  defp dep_changes_in_order(old_deps_info, new_deps_info) do
+  @doc false
+  def dep_changes_in_order(old_deps_info, new_deps_info) do
     new_deps_info
     |> sort_deps()
     |> Enum.flat_map(fn dep ->

--- a/test/core_test.exs
+++ b/test/core_test.exs
@@ -79,7 +79,7 @@ defmodule CoreTest do
 
     # This should not crash and should detect the version change from 1.0.0 to 1.2.3
     changes = Mix.Tasks.Deps.Changelog.dep_changes_in_order(old_deps, new_deps)
-    
+
     assert length(changes) == 1
     {app, old_version, new_version} = hd(changes)
     assert app == :test_dep
@@ -108,7 +108,7 @@ defmodule CoreTest do
     }
 
     changes = Mix.Tasks.Deps.Changelog.dep_changes_in_order([old_dep], [new_dep])
-    
+
     assert length(changes) == 1
     {app, old_version, new_version} = hd(changes)
     assert app == :both_compile

--- a/test/core_test.exs
+++ b/test/core_test.exs
@@ -52,4 +52,67 @@ defmodule CoreTest do
     expected_deps_changelog = File.read!("#{home}/test/fixtures/updated_changelog.md")
     assert deps_changelog == expected_deps_changelog
   end
+
+  test "handles dependencies with :compile status" do
+    # Test the scenario where dep.status is :compile instead of {:ok, version}
+    # This should extract version from the lock info instead
+    dep_with_compile_status = %Mix.Dep{
+      app: :test_dep,
+      status: :compile,
+      opts: [
+        lock: {:hex, :test_dep, "1.2.3", "hash123", [:mix], [], "hexpm", "checksum456"}
+      ],
+      top_level: true
+    }
+
+    dep_with_ok_status = %Mix.Dep{
+      app: :test_dep,
+      status: {:ok, "1.0.0"},
+      opts: [
+        lock: {:hex, :test_dep, "1.0.0", "oldhash", [:mix], [], "hexpm", "oldchecksum"}
+      ],
+      top_level: true
+    }
+
+    old_deps = [dep_with_ok_status]
+    new_deps = [dep_with_compile_status]
+
+    # This should not crash and should detect the version change from 1.0.0 to 1.2.3
+    changes = Mix.Tasks.Deps.Changelog.dep_changes_in_order(old_deps, new_deps)
+    
+    assert length(changes) == 1
+    {app, old_version, new_version} = hd(changes)
+    assert app == :test_dep
+    assert old_version == %Version{major: 1, minor: 0, patch: 0}
+    assert new_version == %Version{major: 1, minor: 2, patch: 3}
+  end
+
+  test "handles dependencies when both old and new have :compile status" do
+    # Test when both old and new deps have :compile status
+    old_dep = %Mix.Dep{
+      app: :both_compile,
+      status: :compile,
+      opts: [
+        lock: {:hex, :both_compile, "2.0.0", "oldhash", [:mix], [], "hexpm", "oldchecksum"}
+      ],
+      top_level: true
+    }
+
+    new_dep = %Mix.Dep{
+      app: :both_compile,
+      status: :compile,
+      opts: [
+        lock: {:hex, :both_compile, "2.1.0", "newhash", [:mix], [], "hexpm", "newchecksum"}
+      ],
+      top_level: true
+    }
+
+    changes = Mix.Tasks.Deps.Changelog.dep_changes_in_order([old_dep], [new_dep])
+    
+    assert length(changes) == 1
+    {app, old_version, new_version} = hd(changes)
+    assert app == :both_compile
+    assert old_version == %Version{major: 2, minor: 0, patch: 0}
+    assert new_version == %Version{major: 2, minor: 1, patch: 0}
+  end
 end


### PR DESCRIPTION
I believe I was running into the same thing as this comment: https://github.com/serpent213/deps_changelog/issues/1#issuecomment-3113980516

When I debug the crash the issue was the `status: :compile` for that dependency.

This adds some calls to `deps.compile` to hopefully address uncompiled deps, as well as a fallback for the version that uses the lock from opts